### PR TITLE
fix: add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     "name": "Manjot Virdi",
     "url": "https://www.manjot.dev/"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mannyv123/cachified-redis-adapter"
+  },
   "license": "ISC",
   "volta": {
     "node": "20.10.0"


### PR DESCRIPTION
We're missing the repository URL on npm 😆 