### PR TITLE
Update README.md to use the correct import (not `-json`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ linked below:**
 // Create an instance of a redis client to pass to the adapter
 // You will need to define this yourself
 import {createClient} from 'redis'
-import {redisCacheAdapter} from 'cachified-redis-json-adapter'
+import {redisCacheAdapter} from 'cachified-redis-adapter'
 
 const redis = createClient({
   /* ...opts */


### PR DESCRIPTION
This was misleading (probably a copy paste error from the other adapter), but the doc says to import from `cachified-redis-json-adapter` instead of `cachified-redis-adapter`

thanks!